### PR TITLE
Fix Auto Recorder plugin to replace slashes in the map name with dashes.

### DIFF
--- a/autorecorder.sp
+++ b/autorecorder.sp
@@ -20,7 +20,7 @@
 #pragma semicolon 1
 #include <sourcemod>
 
-#define PLUGIN_VERSION "1.1.0"
+#define PLUGIN_VERSION "1.1.1"
 
 new Handle:g_hTvEnabled = INVALID_HANDLE;
 new Handle:g_hAutoRecord = INVALID_HANDLE;
@@ -179,6 +179,9 @@ public StartRecord()
 		GetConVarString(g_hDemoPath, sPath, sizeof(sPath));
 		FormatTime(sTime, sizeof(sTime), "%Y%m%d-%H%M%S", GetTime());
 		GetCurrentMap(sMap, sizeof(sMap));
+		
+		// replace slashes in map path name with dashes, to prevent fail on workshop maps
+		ReplaceString(sMap, sizeof(sMap), "/", "-", false);		
 		
 		ServerCommand("tv_record \"%s/auto-%s-%s\"", sPath, sTime, sMap);
 		g_bIsRecording = true;


### PR DESCRIPTION
When using the plugin in CSGO, Auto Recorder will fail to open a demo file for games played on workshop maps. In CSGO, workshop maps are stored in a directory hierarchy, and are identified with a name following following the pattern "workshop/<map_id>/<map_name>.bsp". Auto Recorder would attempt to create demos by concatenating the date with the map name, resulting in the plugin trying to create a demo file in a folder that does not exist. Replacing the slashes with dashes fixed the problem and creates a flat demo folder structure.